### PR TITLE
clean up safety

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -488,8 +488,8 @@ impl<'w, 's> Commands<'w, 's> {
                 queue.push(command);
             }
             InternalQueue::RawCommandQueue(queue) => {
-                // SAFETY: We only ever push to the RawCommandQueue stored on world
-                // which is always valid for the lifetime of the world
+                // SAFETY: `RawCommandQueue` is only every constructed in `Commands::new_raw_from_entities`
+                // where the caller of that has ensured that `queue` outlives `self`
                 unsafe { queue.push(command); }
             }
         }

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -57,7 +57,8 @@ impl<'w> DeferredWorld<'w> {
     pub fn commands(&mut self) -> Commands {
         // SAFETY: &mut self ensure that there are no outstanding accesses to the queue
         let command_queue = unsafe { self.world.get_raw_command_queue() };
-        Commands::new_raw_from_entities(command_queue, self.world.entities())
+        // SAFETY: command_queue is stored on world and always valid while the world exists
+        unsafe { Commands::new_raw_from_entities(command_queue, self.world.entities()) }
     }
 
     /// Retrieves a mutable reference to the given `entity`'s [`Component`] of the given type.

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -569,7 +569,7 @@ impl<'w> UnsafeWorldCell<'w> {
         // SAFETY:
         // - caller ensures there are no existing mutable references
         // - caller ensures that we have permission to access the queue
-        unsafe { (*self.0).command_queue.clone_unsafe() }
+        unsafe { (*self.0).command_queue.clone() }
     }
 }
 


### PR DESCRIPTION
# Objective

- Clean up the safety. Making pointers from references and copying raw pointer is safe. Unsafe comes from trying to use what those pointers point to.
- Main point here is to make `RawCommandQueue::push` unsafe which bubbles up the invariant into `Commands::push`. If I'm following things correctly `InternalCommandQueue::RawCommandQueue` is only constructed from the `RawCommandQueue` stored on world. This command queue is constructed from `RawCommandQueue::new` and the memory from there is always going to be valid, since the memory allocated in `new` needs to be manually dropped.
